### PR TITLE
Return HTTP 400 on unparsable URI

### DIFF
--- a/x3.go
+++ b/x3.go
@@ -73,6 +73,8 @@ func (app *application) fileHandler(w http.ResponseWriter, r *http.Request) {
 	u, err := url.ParseRequestURI(r.RequestURI)
 	if err != nil {
 		fmt.Println("Unable to parse url.")
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
 	}
 	fmt.Println("Serving " + app.config.path + u.Path)
 	// Serve a file from the default directory


### PR DESCRIPTION
The current code falls through when the request URI is unparsable by url.ParseRequestURI(), leaving the "u" to be nil dereferenced below.